### PR TITLE
Add option to connect to alternative running conductor, add help flag

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -12,17 +12,24 @@ function getDnaPath(provisionalPath) {
   }
 }
 
+function noAdminPort() {
+  throw new Error(`
+  Bad input! Cannot use -hc flag without providing an Admin Port.
+  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
+`);
+}
+
 function noIdleM() {
   throw new Error(`
   Bad input! Cannot use -m flag without providing a path to config.
-  USAGE : holochain-run-dna -c <path/to/config.yml> [-m]
+  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
 `);
 }
 
 function badInput() {
   throw new Error(`
   Bad input!
-  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m]
+  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
   CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] [DNA_PATH, DNA_PATH...]
 `);
 }
@@ -68,12 +75,19 @@ export function getAppToInstall() {
       alias: "m",
       boolean: true,
       description: "flag informing whether all apps in config should share an agent or each have their own"
+    })
+    .option("ignore-holochain-conductor", {
+      alias: "hc",
+      boolean: false,
+      description: "flag informing whether the holochain conductor should be run or not"
     }).argv;
 
   const paths = yarg._;
   if (!yarg.config){
     if (yarg.multipleAgents) noIdleM()
     else if (paths.length === 0) badInput();
+  } else {
+    if (yarg.ignoreConductor && !yarg.adminPort) noAdminPort();
   }
 
   const dnas = paths.map((arg) => getDnaPath(arg));
@@ -87,5 +101,6 @@ export function getAppToInstall() {
     proxyUrl: yarg.proxyUrl,
     happs: yarg.config,
     multipleAgents: yarg.multipleAgents,
+    ignoreConductor: yarg.ignoreHolochainConductor,
   };
 }

--- a/src/args.js
+++ b/src/args.js
@@ -17,8 +17,8 @@ function inputGuide(msg, help = false) {
   const logMsg = msg || '';
   throw new Error(`
   ${help ? chalk.bold.yellow('Usage Guide:') : chalk.bold.red('Bad input! ' + logMsg)}
-  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -u [OPEN ADMIN PORT]
-  CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] -u [OPEN ADMIN PORT] [DNA_PATH, DNA_PATH...]
+  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -x [OPEN ADMIN PORT]
+  CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] -x [OPEN ADMIN PORT] [DNA_PATH, DNA_PATH...]
 `);
 }
 
@@ -65,7 +65,7 @@ export function getAppToInstall() {
       description: "flag informing whether all apps in config should share an agent or each have their own"
     })
     .option("use-alternative-conductor-port", {
-      alias: "u",
+      alias: "x",
       type: "integer",
       description: "open port where the admin interface is running (this will automatically skip internal holochain setup and connect to running conductor instead).",
     })

--- a/src/args.js
+++ b/src/args.js
@@ -76,7 +76,7 @@ export function getAppToInstall() {
 
   if (yarg.help) inputGuide(null, yarg.help);
 
-  if (yarg.useAlternativeConductorPort && (typeof yarg.useAlternativeConductorPort !== 'number')) inputGuide('Cannot use -s flag without providing a port number of type integer.');
+  if (yarg.useAlternativeConductorPort && (typeof yarg.useAlternativeConductorPort !== 'number')) inputGuide('Cannot use -x flag without providing a port number of type integer.');
 
   if (!yarg.config){
     if (yarg.multipleAgents) inputGuide('Cannot use -m flag without providing a path to config.');

--- a/src/args.js
+++ b/src/args.js
@@ -17,8 +17,8 @@ function inputGuide(msg, help = false) {
   const logMsg = msg || '';
   throw new Error(`
   ${help ? chalk.bold.yellow('Usage Guide:') : chalk.bold.red('Bad input! ' + logMsg)}
-  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -s [OPEN ADMIN PORT]
-  CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] -s [OPEN ADMIN PORT] [DNA_PATH, DNA_PATH...]
+  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -u [OPEN ADMIN PORT]
+  CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] -u [OPEN ADMIN PORT] [DNA_PATH, DNA_PATH...]
 `);
 }
 
@@ -64,8 +64,8 @@ export function getAppToInstall() {
       boolean: true,
       description: "flag informing whether all apps in config should share an agent or each have their own"
     })
-    .option("skip-conductor-setup", {
-      alias: "s",
+    .option("use-alternative-conductor-port", {
+      alias: "u",
       type: "integer",
       description: "open port where the admin interface is running (this will automatically skip internal holochain setup and connect to running conductor instead).",
     })
@@ -76,7 +76,7 @@ export function getAppToInstall() {
 
   if (yarg.help) inputGuide(null, yarg.help);
 
-  if (yarg.skipConductorSetup && (typeof yarg.skipConductorSetup !== 'number')) inputGuide('Cannot use -s flag without providing a port number of type integer.');
+  if (yarg.useAlternativeConductorPort && (typeof yarg.useAlternativeConductorPort !== 'number')) inputGuide('Cannot use -s flag without providing a port number of type integer.');
 
   if (!yarg.config){
     if (yarg.multipleAgents) inputGuide('Cannot use -m flag without providing a path to config.');
@@ -94,6 +94,6 @@ export function getAppToInstall() {
     proxyUrl: yarg.proxyUrl,
     happs: yarg.config,
     multipleAgents: yarg.multipleAgents,
-    skipConductorSetup: yarg.skipConductorSetup,
+    useAltConductorPort: yarg.useAlternativeConductorPort,
   };
 }

--- a/src/args.js
+++ b/src/args.js
@@ -12,24 +12,17 @@ function getDnaPath(provisionalPath) {
   }
 }
 
-function noAdminPort() {
+function badConfigInput(msg) {
   throw new Error(`
-  Bad input! Cannot use -hc flag without providing an Admin Port.
-  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
+  Bad input! ${msg}
+  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] [-h] -a [ADMIN PORT]
 `);
 }
 
-function noIdleM() {
+function inputGuide(help = true) {
   throw new Error(`
-  Bad input! Cannot use -m flag without providing a path to config.
-  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
-`);
-}
-
-function badInput() {
-  throw new Error(`
-  Bad input!
-  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] -a [ADMIN PORT]
+  ${help ? '--help\n' : 'Bad input!'}
+  CONFIG  FILE  USAGE : holochain-run-dna -c <path/to/config.yml> [-m] [-h] -a [ADMIN PORT]
   CLI  ARGUMENT USAGE : holochain-run-dna -p [PORT] -a [ADMIN PORT] -i [INSTALLED-APP-ID] -r [RUN PATH] -u [PROXY URL] [DNA_PATH, DNA_PATH...]
 `);
 }
@@ -77,17 +70,22 @@ export function getAppToInstall() {
       description: "flag informing whether all apps in config should share an agent or each have their own"
     })
     .option("ignore-holochain-conductor", {
-      alias: "hc",
-      boolean: false,
+      alias: "h",
+      boolean: true,
       description: "flag informing whether the holochain conductor should be run or not"
-    }).argv;
+    })
+    .help('info')
+    .argv;
 
   const paths = yarg._;
+
+  if (yarg.help) inputGuide(yarg.help);
+
   if (!yarg.config){
-    if (yarg.multipleAgents) noIdleM()
-    else if (paths.length === 0) badInput();
+    if (yarg.multipleAgents) badConfigInput('Cannot use -m flag without providing a path to config.');
+    else if (paths.length === 0) inputGuide();
   } else {
-    if (yarg.ignoreConductor && !yarg.adminPort) noAdminPort();
+    if (yarg.ignoreHolochainConductor && !yarg.adminPort) badConfigInput('Cannot use -h flag without providing an Admin Port.');
   }
 
   const dnas = paths.map((arg) => getDnaPath(arg));
@@ -101,6 +99,6 @@ export function getAppToInstall() {
     proxyUrl: yarg.proxyUrl,
     happs: yarg.config,
     multipleAgents: yarg.multipleAgents,
-    ignoreConductor: yarg.ignoreHolochainConductor,
+    ignoreHolochainConductor: yarg.ignoreHolochainConductor,
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ async function execAndInstall(appToInstall) {
   }
 
   let configCreated, realAdminPort
-  if (!appToInstall.skipConductorSetup) {
+  if (!appToInstall.useAltConductorPort) {
     // Execute holochain
     ([configCreated, realAdminPort] = await execHolochain(
       adminPort,
@@ -27,12 +27,12 @@ async function execAndInstall(appToInstall) {
       appToInstall.proxyUrl
       ));
     } else {
-      realAdminPort = appToInstall.skipConductorSetup
+      realAdminPort = appToInstall.useAltConductorPort
       console.log(chalk.bold.blue(`Skipping internal Holochain Conductor setup and instead connecting to admin port of running Conductor at ${realAdminPort}.`))
   }
 
   // If the config file was created assume we also need to install everything
-  if (configCreated || appToInstall.skipConductorSetup) {
+  if (configCreated || appToInstall.useAltConductorPort) {
       await sleep(100);
     
       let adminWebsocket;

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ async function execAndInstall(appToInstall) {
   }
 
   let configCreated, realAdminPort
-  if (!appToInstall.ignoreConductor) {
+  if (!appToInstall.ignoreHolochainConductor) {
     // Execute holochain
     ([configCreated, realAdminPort] = await execHolochain(
       adminPort,
@@ -29,9 +29,9 @@ async function execAndInstall(appToInstall) {
   } else {
     realAdminPort = adminPort
   }
-  
+
   // If the config file was created assume we also need to install everything
-  if (configCreated || appToInstall.ignoreConductor) {
+  if (configCreated || appToInstall.ignoreHolochainConductor) {
       await sleep(100);
     
       let adminWebsocket;

--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,20 @@ async function execAndInstall(appToInstall) {
     adminPort = await getPort({ port: appToInstall.adminPort });
   }
 
-  // Execute holochain
-  const [configCreated, realAdminPort] = await execHolochain(
-    adminPort,
-    appToInstall.runPath,
-    appToInstall.proxyUrl
-  );
+  let configCreated, realAdminPort
+  if (!appToInstall.ignoreConductor) {
+    // Execute holochain
+    ([configCreated, realAdminPort] = await execHolochain(
+      adminPort,
+      appToInstall.runPath,
+      appToInstall.proxyUrl
+    ));
+  } else {
+    realAdminPort = adminPort
+  }
   
   // If the config file was created assume we also need to install everything
-  if (configCreated) {
+  if (configCreated || appToInstall.ignoreConductor) {
       await sleep(100);
     
       let adminWebsocket;

--- a/src/index.js
+++ b/src/index.js
@@ -19,19 +19,20 @@ async function execAndInstall(appToInstall) {
   }
 
   let configCreated, realAdminPort
-  if (!appToInstall.ignoreHolochainConductor) {
+  if (!appToInstall.skipConductorSetup) {
     // Execute holochain
     ([configCreated, realAdminPort] = await execHolochain(
       adminPort,
       appToInstall.runPath,
       appToInstall.proxyUrl
-    ));
-  } else {
-    realAdminPort = adminPort
+      ));
+    } else {
+      realAdminPort = appToInstall.skipConductorSetup
+      console.log(chalk.bold.blue(`Skipping internal Holochain Conductor setup and instead connecting to admin port of running Conductor at ${realAdminPort}.`))
   }
 
   // If the config file was created assume we also need to install everything
-  if (configCreated || appToInstall.ignoreHolochainConductor) {
+  if (configCreated || appToInstall.skipConductorSetup) {
       await sleep(100);
     
       let adminWebsocket;


### PR DESCRIPTION
 > The new cli option separates the tool to install and run of DNAs from the tool to generate a new holochain conductor, allowing `holochain-run-dna` to also be used for only installing and running DNAs.

### Updates: 
 - adds help flag
 - updates bad usage error log
 - adds the option to connect to a running conductor at provided admin port, skipping the conductor setup internal to `holochain-run-dna`. 